### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set version = "2.0.12" %}
-{% set build_number = "0" %}
+{% set build_number = "1" %}
 
-{% set hdf5_version = os.environ.get('HDF5_VERSION', '1.8.17|1.8.17.*').replace('"','')|string %}
+{% set hdf5_version = os.environ.get('HDF5_VERSION', '1.8.18|1.8.18.*').replace('"','')|string %}
 {% set build_string = "py{}_hdf5{}_{}".format(environ.get('CONDA_PY', ''), hdf5_version.split('|')[0], build_number) %}
 
 package:


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For additional info, please see: https://github.com/conda-forge/hdf5-feedstock/pull/68 and https://github.com/conda-forge/hdf5-feedstock/issues/71